### PR TITLE
Fix header issues and duplicate includes

### DIFF
--- a/add_comment.php
+++ b/add_comment.php
@@ -3,7 +3,6 @@ include "database.php";
  
 try {
     $db = getDatabaseConnection();
-    echo "Connected successfully";
 } catch(PDOException $e) {
     echo "Connection failed: " . $e->getMessage();
     exit;
@@ -18,7 +17,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $query = "INSERT INTO comments (post_id, user_id, comment) VALUES (?, ?, ?)";
         $stmt = $db->prepare($query);
         $stmt->execute([$postId, $userId, $content]);
-        echo "Komentarz został dodany!";
         header("Location: commentpostpage.php?id=$postId");
         exit;
     } catch (PDOException $e) {

--- a/add_post.php
+++ b/add_post.php
@@ -11,7 +11,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmt = $db->prepare("INSERT INTO posts (author, title, content) VALUES (?, ?, ?)");
         $stmt->execute([$author, $title, $content]);
  
-        echo "Post dodany!";
         header("Location: glowna.php");
         exit;
     } catch (PDOException $e) {

--- a/deletepost.php
+++ b/deletepost.php
@@ -15,10 +15,8 @@ try {
     $stmt->bindParam(':username', $_COOKIE['username']);
     $stmt->execute();
 
-    if ($stmt->rowCount() > 0) {
-        echo 'Post was successfully deleted';
-    } else {
-        echo 'Could not delete post. Either the post does not exist, or you are not the author of the post';
+    if ($stmt->rowCount() <= 0) {
+        // Optional: handle case when deletion did not occur
     }
 } catch (PDOException $e) {
     echo 'Database error: ' . $e->getMessage();

--- a/loginpage.php
+++ b/loginpage.php
@@ -22,8 +22,7 @@
 <main>
 <?php
     include 'login.php';
-    include 'database.php';
-require_once('database.php');
+    require_once 'database.php';
  
     session_start();
  


### PR DESCRIPTION
## Summary
- remove premature output from add_comment.php and add_post.php
- avoid printing messages when deleting posts
- consolidate database include in login page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857eb7a61348328a2c3e7d95b6438d1