### PR TITLE
Fix user_id constraint for posts

### DIFF
--- a/add_post.php
+++ b/add_post.php
@@ -4,12 +4,12 @@ include 'database.php';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = $_POST['title'];
     $content = $_POST['content'];
-    $author = $_COOKIE['username']; // zakładamy, że masz ciasteczko
+    $userId = $_COOKIE['user_id'];
  
     try {
         $db = getDatabaseConnection();
-        $stmt = $db->prepare("INSERT INTO posts (author, title, content) VALUES (?, ?, ?)");
-        $stmt->execute([$author, $title, $content]);
+        $stmt = $db->prepare("INSERT INTO posts (user_id, title, content, created_at) VALUES (?, ?, ?, NOW())");
+        $stmt->execute([$userId, $title, $content]);
  
         header("Location: glowna.php");
         exit;

--- a/commentpostpage.php
+++ b/commentpostpage.php
@@ -17,20 +17,16 @@ try {
  
     if (isset($_GET['id'])) {
         $postId = $_GET['id'];
-        $query = "SELECT * FROM posts WHERE id = ?";
+        $query = "SELECT p.id, p.title, p.content, p.created_at, u.username AS author
+                  FROM posts p JOIN users u ON p.user_id = u.id WHERE p.id = ?";
         $stmt = $db->prepare($query);
         $stmt->execute([$postId]);
         $post = $stmt->fetch(PDO::FETCH_ASSOC);
- 
+
         if (!$post) {
             die('Post not found.');
         }
- 
-        // Pobierz nazwę autora posta
-        $authorQuery = "SELECT username FROM users WHERE id = ?";
-        $authorStmt = $db->prepare($authorQuery);
-        $authorStmt->execute([$post['user_id']]);
-        $author = $authorStmt->fetchColumn();
+        $author = $post['author'];
  
     } else {
         header('Location: glowna.php');

--- a/deletepost.php
+++ b/deletepost.php
@@ -9,10 +9,10 @@ $postIdToDelete = $_POST['post_id'];
 
 try {
     $db = getDatabaseConnection();
-    $query = 'DELETE FROM posts WHERE id = :id AND author = :username';
+    $query = 'DELETE FROM posts WHERE id = :id AND user_id = :uid';
     $stmt = $db->prepare($query);
     $stmt->bindParam(':id', $postIdToDelete);
-    $stmt->bindParam(':username', $_COOKIE['username']);
+    $stmt->bindParam(':uid', $_COOKIE['user_id']);
     $stmt->execute();
 
     if ($stmt->rowCount() <= 0) {

--- a/glowna.php
+++ b/glowna.php
@@ -19,7 +19,9 @@
     try {
 
         $db = getDatabaseConnection();
-        $query = "SELECT * FROM posts ORDER BY date DESC";
+        $query = "SELECT p.id, p.title, p.content, p.created_at AS date, u.username AS author
+                  FROM posts p JOIN users u ON p.user_id = u.id
+                  ORDER BY p.created_at DESC";
         $stmt = $db->prepare($query);
         $stmt->execute();
         $posts = $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/mypostspage.php
+++ b/mypostspage.php
@@ -36,9 +36,11 @@ logOut();
 <?php
 $db = getDatabaseConnection();
 
-$query = 'SELECT * FROM posts WHERE author = :username ORDER BY date DESC';
+$query = 'SELECT p.id, p.title, p.content, p.created_at AS date, u.username AS author
+          FROM posts p JOIN users u ON p.user_id = u.id
+          WHERE p.user_id = :uid ORDER BY p.created_at DESC';
 $stmt = $db->prepare($query);
-$stmt->bindParam(':username', $_COOKIE['username']);
+$stmt->bindParam(':uid', $_COOKIE['user_id']);
 $stmt->execute();
 
 $posts = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -54,7 +56,7 @@ foreach ($posts as $index => $post) {
     }
 }
 
-if ($displayedPost === null) {
+if ($displayedPost === null && !empty($posts)) {
     $displayedPost = $posts[0];
     $displayedPostIndex = 0;
 }
@@ -65,10 +67,10 @@ if (isset($_POST['delete_post_id'])) {
     $postIdToDelete = $_POST['delete_post_id'];
 
     try {
-        $query = 'DELETE FROM posts WHERE id = :id AND author = :username';
+        $query = 'DELETE FROM posts WHERE id = :id AND user_id = :uid';
         $stmt = $db->prepare($query);
         $stmt->bindParam(':id', $postIdToDelete);
-        $stmt->bindParam(':username', $_COOKIE['username']);
+        $stmt->bindParam(':uid', $_COOKIE['user_id']);
         $stmt->execute();
 
         if ($stmt->rowCount() > 0) {
@@ -84,19 +86,19 @@ if (isset($_POST['delete_post_id'])) {
     $content = isset($_POST['content']) ? $_POST['content'] : null;
 
     try {
-        $author = isset($_COOKIE['username']) ? $_COOKIE['username'] : null;
+        $userId = isset($_COOKIE['user_id']) ? $_COOKIE['user_id'] : null;
 
-        if (!$author) {
-            throw new Exception('Author not found in cookies');
+        if (!$userId) {
+            throw new Exception('User not found in cookies');
         }
 
         $date = date("Y-m-d H:i:s");
 
         $pdo = getDatabaseConnection();
 
-        $stmt = $pdo->prepare("INSERT INTO posts (title, author, content, date) VALUES (?, ?, ?, ?)");
+        $stmt = $pdo->prepare("INSERT INTO posts (user_id, title, content, created_at) VALUES (?, ?, ?, ?)");
 
-        $stmt->execute([$title, $author, $content, $date]);
+        $stmt->execute([$userId, $title, $content, $date]);
 
         echo "Post successfully added.";
         header("Location: " . $_SERVER['PHP_SELF'], true, 303);
@@ -110,21 +112,21 @@ if (isset($_POST['delete_post_id'])) {
     $content = isset($_POST['content']) ? $_POST['content'] : null;
 
     try {
-        $author = isset($_COOKIE['username']) ? $_COOKIE['username'] : null;
+        $userId = isset($_COOKIE['user_id']) ? $_COOKIE['user_id'] : null;
 
-        if (!$author) {
-            throw new Exception('Author not found in cookies');
+        if (!$userId) {
+            throw new Exception('User not found in cookies');
         }
 
         $date = date("Y-m-d H:i:s");
 
-        $stmt = $db->prepare("UPDATE posts SET title = :title, content = :content, date = :date WHERE id = :id AND author = :author");
+        $stmt = $db->prepare("UPDATE posts SET title = :title, content = :content, created_at = :date WHERE id = :id AND user_id = :uid");
 
         $stmt->bindParam(':title', $title);
         $stmt->bindParam(':content', $content);
         $stmt->bindParam(':date', $date);
         $stmt->bindParam(':id', $postIdToUpdate);
-        $stmt->bindParam(':author', $author);
+        $stmt->bindParam(':uid', $userId);
         $stmt->execute();
 
         if ($stmt->rowCount() > 0) {
@@ -180,17 +182,19 @@ if (isset($_POST['delete_post_id'])) {
         </div>
     </div>
     <div class="main-section">
+        <?php if ($displayedPost !== null) : ?>
         <nav class="postpage">
             <form action="mypostspage.php" method="post">
                 <h1>EDIT POST</h1>
                 <label for="title">Title:</label><br>
-                <input type="text" id="title" name="title" value="<?php echo $displayedPost['title']; ?>"><br>
+                <input type="text" id="title" name="title" value="<?php echo htmlspecialchars($displayedPost['title'], ENT_QUOTES); ?>"><br>
                 <label for="content">Content:</label><br>
-                <textarea id="content" name="content"><?php echo $displayedPost['content']; ?></textarea><br>
+                <textarea id="content" name="content"><?php echo htmlspecialchars($displayedPost['content'], ENT_QUOTES); ?></textarea><br>
                 <input type="hidden" name="update_post_id" value="<?php echo $displayedPost['id']; ?>">
                 <input type="submit" value="Update">
             </form>
         </nav>
+        <?php endif; ?>
     </div>
     <div class="main-section">
         <?php


### PR DESCRIPTION
## Summary
- select posts with user IDs joined to usernames
- insert posts with `user_id` and created timestamp
- update and delete posts checking the current user's ID
- simplify single post view query

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ed0b6e748328952afd04212bbfd1